### PR TITLE
Corrected rabbit effect

### DIFF
--- a/src/db/pets/rabbit.ts
+++ b/src/db/pets/rabbit.ts
@@ -13,7 +13,7 @@ function rabbitAbility(level: number): Ability {
       target: {
         kind: "TriggeringEntity",
       },
-      attackAmount: level,
+      healthAmount: level,
       untilEndOfBattle: false,
     },
   };


### PR DESCRIPTION
Rabbit effect was stored as attackAmount. Switched to healthAmount. Change remains consistent with existing db formatting.